### PR TITLE
Add Black (AMOLED) theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Built in theme engine!
 Current themes:
 * Default
 * Night
+* Black (AMOLED)
 
 More to come!
 

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -9,29 +9,40 @@
 			  Open links in a new tab
 
 				<div class="theme-controls">
-			    <h2>Select a theme</h2>
-			    <div>
-			        <label>
-			            <input #default
+				<h2>Select a theme</h2>
+				<div>
+					<label>
+						<input #default
 												name="theme"
 												type="radio"
 												value="default"
 												[checked]="settings.theme === default.value"
 												(click)="selectTheme(default.value)" />
-			            Default
-			        </label>
-			    </div>
-			    <div>
-			        <label>
-			            <input #night
+						Default
+					</label>
+				</div>
+				<div>
+					<label>
+						<input #night
 												name="theme"
 												type="radio"
 												value="night"
 												[checked]="settings.theme === night.value"
 												(click)="selectTheme(night.value)" />
-			          	Night
-			        </label>
-			    </div>
+						Night
+					</label>
+				</div>
+				<div>
+					<label>
+						<input #black
+												name="theme"
+												type="radio"
+												value="black"
+												[checked]="settings.theme === black.value"
+												(click)="selectTheme(black.value)" />
+						Black (AMOLED)
+					</label>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -34,12 +34,12 @@
 				</div>
 				<div>
 					<label>
-						<input #black
+						<input #amoledblack
 												name="theme"
 												type="radio"
-												value="black"
-												[checked]="settings.theme === black.value"
-												(click)="selectTheme(black.value)" />
+												value="amoledblack"
+												[checked]="settings.theme === amoledblack.value"
+												(click)="selectTheme(amoledblack.value)" />
 						Black (AMOLED)
 					</label>
 				</div>

--- a/src/app/shared/_themes.scss
+++ b/src/app/shared/_themes.scss
@@ -33,17 +33,17 @@ $theme-night-logo-inner: $theme-night-header-background-color;
 $theme-night-border: 2px solid #00c0ff;
 
 // Black theme colors
-$theme-black-body-background-color: #000;
-$theme-black-wrapper-background-color: $theme-black-body-background-color;
-$theme-black-wrapper-mobile-background-color: $theme-black-body-background-color;
-$theme-black-text-color: rgba(255, 255, 255, 0.75);
-$theme-black-subtext-color: rgba(255, 255, 255, 0.5);
-$theme-black-secondary-color: rgba(255, 255, 255, 0.6);
-$theme-black-header-background-color: $theme-black-body-background-color;
-$theme-black-logo-inner: $theme-black-header-background-color;
+$theme-amoledblack-body-background-color: #000;
+$theme-amoledblack-wrapper-background-color: $theme-amoledblack-body-background-color;
+$theme-amoledblack-wrapper-mobile-background-color: $theme-amoledblack-body-background-color;
+$theme-amoledblack-text-color: rgba(255, 255, 255, 0.75);
+$theme-amoledblack-subtext-color: rgba(255, 255, 255, 0.5);
+$theme-amoledblack-secondary-color: rgba(255, 255, 255, 0.6);
+$theme-amoledblack-header-background-color: $theme-amoledblack-body-background-color;
+$theme-amoledblack-logo-inner: $theme-amoledblack-header-background-color;
 
 // Black theme extras
-$theme-black-border: $theme-black-secondary-color;
+$theme-amoledblack-border: $theme-amoledblack-secondary-color;
 
 /* ----------------------------------
 
@@ -261,17 +261,17 @@ $theme-black-border: $theme-black-secondary-color;
 );
 
 @include theme(
-  black,
-  $theme-black-body-background-color,
-  $theme-black-wrapper-background-color,
-  $theme-black-wrapper-mobile-background-color,
-  $theme-black-text-color,
-  $theme-black-text-color,
-  $theme-black-header-background-color,
-  $theme-black-subtext-color,
-  $theme-black-secondary-color,
-  $theme-black-logo-inner,
-  $theme-black-border
+  amoledblack,
+  $theme-amoledblack-body-background-color,
+  $theme-amoledblack-wrapper-background-color,
+  $theme-amoledblack-wrapper-mobile-background-color,
+  $theme-amoledblack-text-color,
+  $theme-amoledblack-text-color,
+  $theme-amoledblack-header-background-color,
+  $theme-amoledblack-subtext-color,
+  $theme-amoledblack-secondary-color,
+  $theme-amoledblack-logo-inner,
+  $theme-amoledblack-border
 );
 
 /* ----------------------------------

--- a/src/app/shared/_themes.scss
+++ b/src/app/shared/_themes.scss
@@ -34,16 +34,9 @@ $theme-night-border: 2px solid #00c0ff;
 
 // Black theme colors
 $theme-amoledblack-body-background-color: #000;
-$theme-amoledblack-wrapper-background-color: $theme-amoledblack-body-background-color;
-$theme-amoledblack-wrapper-mobile-background-color: $theme-amoledblack-body-background-color;
 $theme-amoledblack-text-color: rgba(255, 255, 255, 0.75);
 $theme-amoledblack-subtext-color: rgba(255, 255, 255, 0.5);
 $theme-amoledblack-secondary-color: rgba(255, 255, 255, 0.6);
-$theme-amoledblack-header-background-color: $theme-amoledblack-body-background-color;
-$theme-amoledblack-logo-inner: $theme-amoledblack-header-background-color;
-
-// Black theme extras
-$theme-amoledblack-border: $theme-amoledblack-secondary-color;
 
 /* ----------------------------------
 
@@ -263,15 +256,15 @@ $theme-amoledblack-border: $theme-amoledblack-secondary-color;
 @include theme(
   amoledblack,
   $theme-amoledblack-body-background-color,
-  $theme-amoledblack-wrapper-background-color,
-  $theme-amoledblack-wrapper-mobile-background-color,
+  $theme-amoledblack-body-background-color,
+  $theme-amoledblack-body-background-color,
   $theme-amoledblack-text-color,
   $theme-amoledblack-text-color,
-  $theme-amoledblack-header-background-color,
+  $theme-amoledblack-body-background-color,
   $theme-amoledblack-subtext-color,
   $theme-amoledblack-secondary-color,
-  $theme-amoledblack-logo-inner,
-  $theme-amoledblack-border
+  $theme-amoledblack-body-background-color,
+  $theme-amoledblack-secondary-color
 );
 
 /* ----------------------------------

--- a/src/app/shared/_themes.scss
+++ b/src/app/shared/_themes.scss
@@ -32,6 +32,19 @@ $theme-night-logo-inner: $theme-night-header-background-color;
 // Night theme extras
 $theme-night-border: 2px solid #00c0ff;
 
+// Black theme colors
+$theme-black-body-background-color: #000;
+$theme-black-wrapper-background-color: $theme-black-body-background-color;
+$theme-black-wrapper-mobile-background-color: $theme-black-body-background-color;
+$theme-black-text-color: rgba(255, 255, 255, 0.75);
+$theme-black-subtext-color: rgba(255, 255, 255, 0.5);
+$theme-black-secondary-color: rgba(255, 255, 255, 0.6);
+$theme-black-header-background-color: $theme-black-body-background-color;
+$theme-black-logo-inner: $theme-black-header-background-color;
+
+// Black theme extras
+$theme-black-border: $theme-black-secondary-color;
+
 /* ----------------------------------
 
   Want a new theme? Add your new theme variables here!
@@ -245,6 +258,20 @@ $theme-night-border: 2px solid #00c0ff;
   $theme-night-secondary-color,
   $theme-night-logo-inner,
   $theme-night-border
+);
+
+@include theme(
+  black,
+  $theme-black-body-background-color,
+  $theme-black-wrapper-background-color,
+  $theme-black-wrapper-mobile-background-color,
+  $theme-black-text-color,
+  $theme-black-text-color,
+  $theme-black-header-background-color,
+  $theme-black-subtext-color,
+  $theme-black-secondary-color,
+  $theme-black-logo-inner,
+  $theme-black-border
 );
 
 /* ----------------------------------


### PR DESCRIPTION
Adds a black theme for AMOLED screens (turns black pixels off, saving battery life and eye strain).

<img width="318" alt="screen shot 2017-01-19 at 12 41 26" src="https://cloud.githubusercontent.com/assets/1525809/22107256/b9521074-de44-11e6-8805-c952f277b9f6.png">
<img width="317" alt="screen shot 2017-01-19 at 12 41 32" src="https://cloud.githubusercontent.com/assets/1525809/22107257/b9534a20-de44-11e6-93b7-a63e6eb22384.png">
<img width="316" alt="screen shot 2017-01-19 at 12 41 51" src="https://cloud.githubusercontent.com/assets/1525809/22107258/b95625a6-de44-11e6-9530-a1975bf536e1.png">

<img width="1345" alt="screen shot 2017-01-19 at 12 43 03" src="https://cloud.githubusercontent.com/assets/1525809/22107290/db39bfb6-de44-11e6-8715-c093658f076c.png">
