### PR TITLE
Fix accessibility error

### DIFF
--- a/src/app/core/header/header.component.scss
+++ b/src/app/core/header/header.component.scss
@@ -106,7 +106,7 @@ h1 {
   }
 
   a {
-    color: hsla(0,0%,100%,.8);
+    color: hsla(0,0%,100%,.9);
     text-decoration: none;
     margin: 0 5px;
     letter-spacing: 1.8px;


### PR DESCRIPTION
The links in the navbar are just slightly under the contrast ratio requirement and thus get marked down on the Lighthouse score. Changing the opacity from 0.8 to 0.9 corrects this.
![accessibility fail](https://cloud.githubusercontent.com/assets/9759954/25025242/7109af9e-206f-11e7-82e3-6f51d238cb56.JPG)
