### PR TITLE
Fix bad autoprefixer rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,10 @@
     "tslint": "~4.5.1",
     "typescript": "~2.2.1",
     "webpack-bundle-analyzer": "^2.3.0"
-  }
+  },
+  "browserslist": [
+    "last 2 versions", 
+    "not ie <= 10", 
+    "not ie_mob <= 10"
+  ]
 }


### PR DESCRIPTION
Currently the autoprefixer is adding some outdated flexbox prefixing such that the Lighthouse score is being hurt. Adding a browserslist config to the package.json rule sends the correct message to the autoprefixer and fixes this error.

Error currently:
![image](https://cloud.githubusercontent.com/assets/9759954/25026222/7a31ca94-2073-11e7-8931-75edf6fe198b.png)
**This PR fixes the error.**